### PR TITLE
TUR-21619: Prototype Custom Scheduler

### DIFF
--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -61,6 +61,7 @@ class DSession:
         self._failed_nodes_count = 0
         self.saved_put = None
         self.remake_nodes = False
+        self.actually_started = False
         self._max_worker_restart = get_default_max_worker_restart(self.config)
         # summary message to print at the end of the session
         self._summary_report: str | None = None
@@ -182,7 +183,7 @@ class DSession:
                     for node in self.sched.nodes:
                         if len(self.sched.node2pending[node]) not in [0, 1]:
                             all_nodes_finishing = False
-                    if all_nodes_finishing:
+                    if all_nodes_finishing and self.actually_started:
                         # If all have 1 test remaining (or 0, since some nodes won't be used)
                         # Then have each node shutdown, then restart each node, and replace the nodes in sched.nodes,
                         # then call check_schedule()
@@ -348,6 +349,7 @@ class DSession:
                     self.terminal.write_line(
                         f"scheduling tests via {self.sched.__class__.__name__}"
                     )
+            self.actually_started = True
             self.sched.schedule()
 
     def worker_logstart(

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -159,6 +159,12 @@ class DSession:
                 if self.remake_nodes:
                     self.terminal.write_line("\n")
                     self.remake_nodes = False
+
+                    num_workers = self.sched.dist_groups[self.sched.pending_groups[0]]['group_workers']
+                    if num_workers < len(self.nodemanager.specs):
+                        self.nodemanager.specs = self.nodemanager.specs[0:num_workers]
+                    self.trdist._status = {}
+
                     new_nodes = self.nodemanager.setup_nodes(self.saved_put)
                     self._active_nodes = set()
                     self._active_nodes.update(new_nodes)

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -178,11 +178,11 @@ class DSession:
             except Empty:
                 # Custom logic for CustomGroup scheduler:
                 if isinstance(self.sched, CustomGroup):
-                    all_one = True
+                    all_nodes_finishing = True
                     for node in self.sched.nodes:
                         if len(self.sched.node2pending[node]) not in [0, 1]:
-                            all_one = False
-                    if all_one:
+                            all_nodes_finishing = False
+                    if all_nodes_finishing:
                         # If all have 1 test remaining (or 0, since some nodes won't be used)
                         # Then have each node shutdown, then restart each node, and replace the nodes in sched.nodes,
                         # then call check_schedule()
@@ -242,7 +242,6 @@ class DSession:
         if self.remake_nodes:
             node.ensure_teardown()
             self._active_nodes.remove(node)
-            self.do_breakpoint = True
             return
         self.config.hook.pytest_testnodedown(node=node, error=None)
         if node.workeroutput["exitstatus"] == 2:  # keyboard-interrupt

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -157,6 +157,7 @@ class DSession:
         while 1:
             if not self._active_nodes:
                 if self.remake_nodes:
+                    self.terminal.write_line(f"Remaking nodes, overwriting node2pending")
                     self.remake_nodes = False
                     new_nodes = self.nodemanager.setup_nodes(self.saved_put)
                     self._active_nodes = set()
@@ -196,6 +197,7 @@ class DSession:
                         if len(self.sched.pending) != 0:
                             self.remake_nodes = True
                             num_nodes = len(self.sched.nodes)
+                        self.terminal.write_line(f"Shutting down all nodes")
                         for node in self.sched.nodes:
                             node.shutdown()
                             #node.ensure_teardown()
@@ -249,6 +251,7 @@ class DSession:
             node.shutdown()
         else:
             assert self.sched is not None
+            self.terminal.write_line(f"Running add node for {node}")
             self.sched.add_node(node)
 
     def worker_workerfinished(self, node: WorkerController) -> None:
@@ -260,9 +263,8 @@ class DSession:
         workerready before shutdown was triggered.
         """
         if self.remake_nodes:
-            for node in self.sched.nodes:
-                node.ensure_teardown()
-                self._active_nodes = set()
+            node.ensure_teardown()
+            self._active_nodes.remove(node)
             self.do_breakpoint = True
             return
         self.config.hook.pytest_testnodedown(node=node, error=None)

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -157,7 +157,6 @@ class DSession:
         while 1:
             if not self._active_nodes:
                 if self.remake_nodes:
-                    self.terminal.write_line(f"Remaking nodes, overwriting node2pending")
                     self.remake_nodes = False
                     new_nodes = self.nodemanager.setup_nodes(self.saved_put)
                     self._active_nodes = set()
@@ -182,7 +181,6 @@ class DSession:
                 # self.nodemanager = NodeManager(self.config)
                 # nodes = self.nodemanager.setup_nodes(putevent=self.queue.put)
                 # self._active_nodes.update(nodes)
-                self.terminal.write_line(f"Here! iteration: {x}\n{self.sched.node2pending}\n\n")
                 all_one = True
                 for node in self.sched.nodes:
                     if len(self.sched.node2pending[node]) not in [0, 1]:
@@ -197,7 +195,6 @@ class DSession:
                         if len(self.sched.pending) != 0:
                             self.remake_nodes = True
                             num_nodes = len(self.sched.nodes)
-                        self.terminal.write_line(f"Shutting down all nodes")
                         for node in self.sched.nodes:
                             node.shutdown()
                             #node.ensure_teardown()
@@ -219,7 +216,6 @@ class DSession:
         callname, kwargs = eventcall
         # self.terminal.write_line(f"Got callname: {callname}")
         assert callname, kwargs
-        self.terminal.write_line(f"Making call: {callname}")
         method = "worker_" + callname
         call = getattr(self, method)
         self.log("calling method", method, kwargs)
@@ -251,7 +247,6 @@ class DSession:
             node.shutdown()
         else:
             assert self.sched is not None
-            self.terminal.write_line(f"Running add node for {node}")
             self.sched.add_node(node)
 
     def worker_workerfinished(self, node: WorkerController) -> None:

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -148,6 +148,7 @@ class DSession:
 
     def loop_once(self) -> None:
         """Process one callback from one of the workers."""
+        x = 0
         while 1:
             if not self._active_nodes:
                 # If everything has died stop looping
@@ -157,8 +158,19 @@ class DSession:
                 eventcall = self.queue.get(timeout=2.0)
                 break
             except Empty:
+                x += 1
+                self.terminal.write_line(f"Here! iteration: {x}\n{self.sched.node2pending}\n\n")
+                all_one = True
+                for node in self.sched.nodes:
+                    if len(self.sched.node2pending[node]) not in [0, 1]:
+                        all_one = False
+                if all_one:
+                    self.terminal.write_line(f"Calling check_schedule")
+                    self.sched.check_schedule(self.sched.nodes[0], 1.0, True)
+                #breakpoint()
                 continue
         callname, kwargs = eventcall
+        # self.terminal.write_line(f"Got callname: {callname}")
         assert callname, kwargs
         method = "worker_" + callname
         call = getattr(self, method)

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -160,11 +160,9 @@ class DSession:
                     self.remake_nodes = False
 
                     num_workers = self.sched.dist_groups[self.sched.pending_groups[0]]['group_workers']
-                    if num_workers < len(self.nodemanager.specs):
-                        self.nodemanager.specs = self.nodemanager.specs[0:num_workers]
                     self.trdist._status = {}
 
-                    new_nodes = self.nodemanager.setup_nodes(self.saved_put)
+                    new_nodes = self.nodemanager.setup_nodes(self.saved_put, num_workers)
                     self._active_nodes = set()
                     self._active_nodes.update(new_nodes)
                     self.sched.node2pending = {}

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -21,6 +21,7 @@ from xdist.scheduler import LoadScheduling
 from xdist.scheduler import LoadScopeScheduling
 from xdist.scheduler import Scheduling
 from xdist.scheduler import WorkStealingScheduling
+from xdist.scheduler import CustomGroup
 from xdist.workermanage import NodeManager
 from xdist.workermanage import WorkerController
 
@@ -123,6 +124,8 @@ class DSession:
             return LoadGroupScheduling(config, log)
         if dist == "worksteal":
             return WorkStealingScheduling(config, log)
+        if dist == "customgroup":
+            return CustomGroup(config, log)
         return None
 
     @pytest.hookimpl

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -157,6 +157,7 @@ class DSession:
         while 1:
             if not self._active_nodes:
                 if self.remake_nodes:
+                    self.terminal.write_line("\n")
                     self.remake_nodes = False
                     new_nodes = self.nodemanager.setup_nodes(self.saved_put)
                     self._active_nodes = set()

--- a/src/xdist/plugin.py
+++ b/src/xdist/plugin.py
@@ -108,6 +108,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "loadfile",
             "loadgroup",
             "worksteal",
+            "customgroup",
             "no",
         ],
         dest="dist",
@@ -124,6 +125,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "loadgroup: Like 'load', but sends tests marked with 'xdist_group' to the same worker.\n\n"
             "worksteal: Split the test suite between available environments,"
             " then re-balance when any worker runs out of tests.\n\n"
+            # TODO: Update docstring
+            "customgroup: TODO: add docs here"
             "(default) no: Run tests inprocess, don't distribute."
         ),
     )

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -207,9 +207,10 @@ class WorkerInteractor:
         items: list[pytest.Item],
     ) -> None:
         # add the group name to nodeid as suffix if --dist=loadgroup
-        if config.getvalue("loadgroup"):
+        if config.getvalue("loadgroup") or config.getvalue("customgroup"):
+            functional_mark = "xdist_group" if config.getvalue("loadgroup") else "xdist_custom"
             for item in items:
-                mark = item.get_closest_marker("xdist_group")
+                mark = item.get_closest_marker(functional_mark)
                 if not mark:
                     continue
                 gname = (
@@ -357,6 +358,7 @@ def getinfodict() -> WorkerInfo:
 
 def setup_config(config: pytest.Config, basetemp: str | None) -> None:
     config.option.loadgroup = config.getvalue("dist") == "loadgroup"
+    config.option.customgroup = config.getvalue("dist") == "customgroup"
     config.option.looponfail = False
     config.option.usepdb = False
     config.option.dist = "no"

--- a/src/xdist/remote.py
+++ b/src/xdist/remote.py
@@ -201,6 +201,7 @@ class WorkerInteractor:
             "runtest_protocol_complete", item_index=self.item_index, duration=duration
         )
 
+    @pytest.mark.trylast
     def pytest_collection_modifyitems(
         self,
         config: pytest.Config,

--- a/src/xdist/scheduler/__init__.py
+++ b/src/xdist/scheduler/__init__.py
@@ -1,5 +1,6 @@
 from xdist.scheduler.each import EachScheduling as EachScheduling
 from xdist.scheduler.load import LoadScheduling as LoadScheduling
+from xdist.scheduler.customgroup import CustomGroup as CustomGroup
 from xdist.scheduler.loadfile import LoadFileScheduling as LoadFileScheduling
 from xdist.scheduler.loadgroup import LoadGroupScheduling as LoadGroupScheduling
 from xdist.scheduler.loadscope import LoadScopeScheduling as LoadScopeScheduling

--- a/src/xdist/scheduler/customgroup.py
+++ b/src/xdist/scheduler/customgroup.py
@@ -1,0 +1,406 @@
+"""Run tests across a variable number of nodes based on custom groups.
+
+# TODO: This is more of a spec/description, update docs/remove this section document within the class
+Example:
+    - 10 test cases exist
+    - 4 test cases are marked with @pytest.mark.low
+    - 4 test cases are marked with @pytest.mark.medium
+    - 2 test cases are marked with @pytest.mark.high
+    - A pytest.ini file contains the following lines:
+[pytest]
+
+markers=
+    low: 4
+    medium: 2
+    high: 1
+
+Then the 4 low test cases will be ran on 4 workers (distributed evenly amongst the 4, as the load.py scheduler functions)
+Then the 4 medium test cases will be ran on 2 workers (again, distributed evenly), only after the low test cases are complete (or before they start).
+Then the 2 high test cases will be ran on 1 worker (distributed evenly), only after the low and medium test cases are complete (or before they start).
+
+This allows a pytest user more custom control over processing tests.
+One potential application would be measuring the resource utilization of all test cases. Test cases that are not
+resource intensive can be ran on many workers, and more resource intensive test cases can be ran once the low
+resource consuming tests are done on fewer workers, such that resource consumption does not exceed available resources.
+"""
+from __future__ import annotations
+
+from itertools import cycle
+from typing import Sequence
+
+import pytest
+
+from xdist.remote import Producer, WorkerInteractor
+from xdist.report import report_collection_diff
+from xdist.workermanage import parse_spec_config
+from xdist.workermanage import WorkerController
+
+class CustomGroup:
+    """
+    # TODO: update docs here
+    """
+
+    def __init__(self, config: pytest.Config, log: Producer | None = None) -> None:
+        self.numnodes = len(parse_spec_config(config))
+        self.node2collection: dict[WorkerController, list[str]] = {}
+        self.node2pending: dict[WorkerController, list[int]] = {}
+        self.pending: list[int] = []
+        self.collection: list[str] | None = None
+        if log is None:
+            self.log = Producer("loadsched")
+        else:
+            self.log = log.loadsched
+        self.config = config
+        self.maxschedchunk = self.config.getoption("maxschedchunk")
+        # TODO: Type annotation incorrect
+        self.dist_groups: dict[str, str] = {}
+        self.is_first_time = True
+
+    @property
+    def nodes(self) -> list[WorkerController]:
+        """A list of all nodes in the scheduler."""
+        return list(self.node2pending.keys())
+
+    @property
+    def collection_is_completed(self) -> bool:
+        """Boolean indication initial test collection is complete.
+
+        This is a boolean indicating all initial participating nodes
+        have finished collection.  The required number of initial
+        nodes is defined by ``.numnodes``.
+        """
+        return len(self.node2collection) >= self.numnodes
+
+    @property
+    def tests_finished(self) -> bool:
+        """Return True if all tests have been executed by the nodes."""
+        if not self.collection_is_completed:
+            return False
+        if self.pending:
+            return False
+        for pending in self.node2pending.values():
+            if len(pending) >= 2:
+                return False
+        return True
+
+    @property
+    def has_pending(self) -> bool:
+        """Return True if there are pending test items.
+
+        This indicates that collection has finished and nodes are
+        still processing test items, so this can be thought of as
+        "the scheduler is active".
+        """
+        if self.pending:
+            return True
+        for pending in self.node2pending.values():
+            if pending:
+                return True
+        return False
+
+    def add_node(self, node: WorkerController) -> None:
+        """Add a new node to the scheduler.
+
+        From now on the node will be allocated chunks of tests to
+        execute.
+
+        Called by the ``DSession.worker_workerready`` hook when it
+        successfully bootstraps a new node.
+        """
+        assert node not in self.node2pending
+        self.node2pending[node] = []
+
+    def add_node_collection(
+        self, node: WorkerController, collection: Sequence[str]
+    ) -> None:
+        """Add the collected test items from a node.
+
+        The collection is stored in the ``.node2collection`` map.
+        Called by the ``DSession.worker_collectionfinish`` hook.
+        """
+        assert node in self.node2pending
+        if self.collection_is_completed:
+            # A new node has been added later, perhaps an original one died.
+            # .schedule() should have
+            # been called by now
+            assert self.collection
+            if collection != self.collection:
+                other_node = next(iter(self.node2collection.keys()))
+                msg = report_collection_diff(
+                    self.collection, collection, other_node.gateway.id, node.gateway.id
+                )
+                self.log(msg)
+                return
+        self.node2collection[node] = list(collection)
+
+    def mark_test_complete(
+        self, node: WorkerController, item_index: int, duration: float = 0
+    ) -> None:
+        """Mark test item as completed by node.
+
+        The duration it took to execute the item is used as a hint to
+        the scheduler.
+
+        This is called by the ``DSession.worker_testreport`` hook.
+        """
+
+        self.node2pending[node].remove(item_index)
+        self.check_schedule(node, duration=duration)
+
+    def mark_test_pending(self, item: str) -> None:
+
+        assert self.collection is not None
+        self.pending.insert(
+            0,
+            self.collection.index(item),
+        )
+        for node in self.node2pending:
+            self.check_schedule(node)
+
+    def remove_pending_tests_from_node(
+        self,
+        node: WorkerController,
+        indices: Sequence[int],
+    ) -> None:
+        raise NotImplementedError()
+
+    def check_schedule(self, node: WorkerController, duration: float = 0) -> None:
+        """Maybe schedule new items on the node.
+
+        If there are any globally pending nodes left then this will
+        check if the given node should be given any more tests.  The
+        ``duration`` of the last test is optionally used as a
+        heuristic to influence how many tests the node is assigned.
+        """
+        breakpoint()
+        if node.shutting_down:
+            return
+        if self.pending:
+            any_working = False
+            for node in self.nodes:
+                if self.node2pending[node]:
+                    any_working = True
+
+            if not any_working:
+                for dist_group_key in self.dist_groups:
+                    dist_group = self.dist_groups[dist_group_key]
+                    nodes = cycle(self.nodes[0:dist_group['group_workers']])
+                    for _ in range(len(dist_group['test_indices'])):
+                        self._send_tests_group(next(nodes), 1, dist_group_key)
+                    pending_nodes = self.nodes[0:dist_group['group_workers']]
+                    del self.dist_groups[dist_group_key]
+                    break
+        #     # how many nodes do we have?
+        #     num_nodes = len(self.node2pending)
+        #     # if our node goes below a heuristic minimum, fill it out to
+        #     # heuristic maximum
+        #     items_per_node_min = max(2, len(self.pending) // num_nodes // 4)
+        #     items_per_node_max = max(2, len(self.pending) // num_nodes // 2)
+        #     node_pending = self.node2pending[node]
+        #     if len(node_pending) < items_per_node_min:
+        #         if duration >= 0.1 and len(node_pending) >= 2:
+        #             # seems the node is doing long-running tests
+        #             # and has enough items to continue
+        #             # so let's rather wait with sending new items
+        #             return
+        #         num_send = items_per_node_max - len(node_pending)
+        #         # keep at least 2 tests pending even if --maxschedchunk=1
+        #         maxschedchunk = max(2 - len(node_pending), self.maxschedchunk)
+        #         self._send_tests(node, min(num_send, maxschedchunk))
+        else:
+            node.shutdown()
+
+        self.log("num items waiting for node:", len(self.pending))
+
+    def remove_node(self, node: WorkerController) -> str | None:
+        """Remove a node from the scheduler.
+
+        This should be called either when the node crashed or at
+        shutdown time.  In the former case any pending items assigned
+        to the node will be re-scheduled.  Called by the
+        ``DSession.worker_workerfinished`` and
+        ``DSession.worker_errordown`` hooks.
+
+        Return the item which was being executing while the node
+        crashed or None if the node has no more pending items.
+
+        """
+        pending = self.node2pending.pop(node)
+        if not pending:
+            return None
+
+        # The node crashed, reassing pending items
+        assert self.collection is not None
+        crashitem = self.collection[pending.pop(0)]
+        self.pending.extend(pending)
+        for node in self.node2pending:
+            self.check_schedule(node)
+        return crashitem
+
+    def schedule(self) -> None:
+        """Initiate distribution of the test collection.
+
+        Initiate scheduling of the items across the nodes.  If this
+        gets called again later it behaves the same as calling
+        ``.check_schedule()`` on all nodes so that newly added nodes
+        will start to be used.
+
+        This is called by the ``DSession.worker_collectionfinish`` hook
+        if ``.collection_is_completed`` is True.
+        """
+        assert self.collection_is_completed
+
+        # Initial distribution already happened, reschedule on all nodes
+        if self.collection is not None:
+            for node in self.nodes:
+                self.check_schedule(node)
+            return
+
+        # XXX allow nodes to have different collections
+        if not self._check_nodes_have_same_collection():
+            self.log("**Different tests collected, aborting run**")
+            return
+
+        # Collections are identical, create the index of pending items.
+        self.collection = next(iter(self.node2collection.values()))
+        self.pending[:] = range(len(self.collection))
+        if not self.collection:
+            return
+
+        if self.maxschedchunk is None:
+            self.maxschedchunk = len(self.collection)
+
+        dist_groups = {}
+        #####
+        if self.is_first_time:
+            for i, test in enumerate(self.collection):
+                if '@' in test:
+                    group_mark = test.split('@')[-1]
+                    group_workers = int(group_mark.split('_')[-1])
+                    if group_workers > len(self.nodes):
+                        # We can only distribute across as many nodes as we have available
+                        # If a group requests more, we fallback to our actual max
+                        group_workers = len(self.nodes)
+                else:
+                    group_mark = 'default'
+                    group_workers = len(self.nodes)
+                existing_tests = dist_groups.get(group_mark, {}).get('tests', [])
+                existing_tests.append(test)
+                existing_indices = dist_groups.get(group_mark, {}).get('test_indices', [])
+                existing_indices.append(i)
+
+                dist_groups[group_mark] = {
+                    'tests': existing_tests,
+                    'group_workers': group_workers,
+                    'test_indices': existing_indices,
+                    'pending_indices': existing_indices
+                }
+            self.dist_groups = dist_groups
+            self.is_first_time = False
+        else:
+            for node in self.nodes:
+                self.check_schedule(node)
+
+        # TODO: 8/14/2024: dist_groups appear to be correct, but execution on workers is all janked up
+        # figure out what is going on in this for loop and correct it for a bare bones prototype
+
+        ## new attempt
+
+        ## end new attempt
+
+        for dist_group_key in self.dist_groups:
+            dist_group = self.dist_groups[dist_group_key]
+            nodes = cycle(self.nodes[0:dist_group['group_workers']])
+            for _ in range(len(dist_group['test_indices'])):
+                self._send_tests_group(next(nodes), 1, dist_group_key)
+            del self.dist_groups[dist_group_key]
+            break
+            #worker_int = WorkerInteractor(self.nodes[0].config, self.nodes[0].channel)
+            #new_conf = self.nodes[0].config.__dict__['workerinput'] = self.nodes[0].workerinput
+            #worker_int = self.nodes[0].RemoteHook.pytest_xdist_getremotemodule(self).WorkerInteractor(new_conf, self.nodes[0].channel)
+            # while True:
+            #     # Loop and check node status, do not move on to next dist_group until all
+            #     # nodes in the cycle are idle
+            #     node = next(nodes)
+            #     if self.node2pending[node]:
+            #         continue
+            #     else:
+            #         breakpoint()
+        # breakpoint()
+        #####
+
+        # # Send a batch of tests to run. If we don't have at least two
+        # # tests per node, we have to send them all so that we can send
+        # # shutdown signals and get all nodes working.
+        # if len(self.pending) < 2 * len(self.nodes):
+        #     # Distribute tests round-robin. Try to load all nodes if there are
+        #     # enough tests. The other branch tries sends at least 2 tests
+        #     # to each node - which is suboptimal when you have less than
+        #     # 2 * len(nodes) tests.
+        #     nodes = cycle(self.nodes)
+        #     for _ in range(len(self.pending)):
+        #         self._send_tests(next(nodes), 1)
+        # else:
+        #     # Send batches of consecutive tests. By default, pytest sorts tests
+        #     # in order for optimal single-threaded execution, minimizing the
+        #     # number of necessary fixture setup/teardown. Try to keep that
+        #     # optimal order for every worker.
+
+        #     # how many items per node do we have about?
+        #     items_per_node = len(self.collection) // len(self.node2pending)
+        #     # take a fraction of tests for initial distribution
+        #     node_chunksize = min(items_per_node // 4, self.maxschedchunk)
+        #     node_chunksize = max(node_chunksize, 2)
+        #     # and initialize each node with a chunk of tests
+        #     for node in self.nodes:
+        #         self._send_tests(node, node_chunksize)
+        #if not self.pending:
+            #initial distribution sent all tests, start node shutdown
+        #self.check_schedule()
+        for node in self.nodes:
+            self.check_schedule(node)
+
+    def _send_tests(self, node: WorkerController, num: int) -> None:
+        tests_per_node = self.pending[:num]
+        if tests_per_node:
+            del self.pending[:num]
+            self.node2pending[node].extend(tests_per_node)
+            node.send_runtest_some(tests_per_node)
+
+    def _send_tests_group(self, node: WorkerController, num: int, dist_group_key) -> None:
+        tests_per_node = self.dist_groups[dist_group_key]['pending_indices'][:num]
+        if tests_per_node:
+            del self.dist_groups[dist_group_key]['pending_indices'][:num]
+            for test_index in tests_per_node:
+                self.pending.remove(test_index)
+            self.node2pending[node].extend(tests_per_node)
+            node.send_runtest_some(tests_per_node)
+
+
+    def _check_nodes_have_same_collection(self) -> bool:
+        """Return True if all nodes have collected the same items.
+
+        If collections differ, this method returns False while logging
+        the collection differences and posting collection errors to
+        pytest_collectreport hook.
+        """
+        node_collection_items = list(self.node2collection.items())
+        first_node, col = node_collection_items[0]
+        same_collection = True
+        for node, collection in node_collection_items[1:]:
+            msg = report_collection_diff(
+                col, collection, first_node.gateway.id, node.gateway.id
+            )
+            if msg:
+                same_collection = False
+                self.log(msg)
+                if self.config is not None:
+                    rep = pytest.CollectReport(
+                        nodeid=node.gateway.id,
+                        outcome="failed",
+                        longrepr=msg,
+                        result=[],
+                    )
+                    self.config.hook.pytest_collectreport(report=rep)
+
+        return same_collection

--- a/src/xdist/scheduler/customgroup.py
+++ b/src/xdist/scheduler/customgroup.py
@@ -143,7 +143,7 @@ class CustomGroup:
 
         This is called by the ``DSession.worker_testreport`` hook.
         """
-
+        # breakpoint()
         self.node2pending[node].remove(item_index)
         self.check_schedule(node, duration=duration)
 
@@ -164,7 +164,7 @@ class CustomGroup:
     ) -> None:
         raise NotImplementedError()
 
-    def check_schedule(self, node: WorkerController, duration: float = 0) -> None:
+    def check_schedule(self, node: WorkerController, duration: float = 0, from_dsession=False) -> None:
         """Maybe schedule new items on the node.
 
         If there are any globally pending nodes left then this will
@@ -172,16 +172,24 @@ class CustomGroup:
         ``duration`` of the last test is optionally used as a
         heuristic to influence how many tests the node is assigned.
         """
-        breakpoint()
         if node.shutting_down:
             return
+        # if len(self.node2pending[node]) == 1:
+        #     node.shutdown()
+        #     node.setup()
+        #     return
+
         if self.pending:
             any_working = False
             for node in self.nodes:
-                if self.node2pending[node]:
+                if len(self.node2pending[node]) not in [0, 1]:
                     any_working = True
+            # any_working = False
+            # for node in self.nodes:
+            #     if len(self.node2pending[node]) not in [0]:
+            #         any_working = True
 
-            if not any_working:
+            if not any_working and from_dsession:
                 for dist_group_key in self.dist_groups:
                     dist_group = self.dist_groups[dist_group_key]
                     nodes = cycle(self.nodes[0:dist_group['group_workers']])
@@ -357,8 +365,9 @@ class CustomGroup:
         #if not self.pending:
             #initial distribution sent all tests, start node shutdown
         #self.check_schedule()
-        for node in self.nodes:
-            self.check_schedule(node)
+        # breakpoint()
+        # for node in self.nodes:
+        #     self.check_schedule(node)
 
     def _send_tests(self, node: WorkerController, num: int) -> None:
         tests_per_node = self.pending[:num]

--- a/src/xdist/scheduler/customgroup.py
+++ b/src/xdist/scheduler/customgroup.py
@@ -55,6 +55,7 @@ class CustomGroup:
         # TODO: Type annotation incorrect
         self.dist_groups: dict[str, str] = {}
         self.is_first_time = True
+        self.do_resched = False
 
     @property
     def nodes(self) -> list[WorkerController]:

--- a/src/xdist/scheduler/customgroup.py
+++ b/src/xdist/scheduler/customgroup.py
@@ -146,7 +146,6 @@ class CustomGroup:
 
         This is called by the ``DSession.worker_testreport`` hook.
         """
-        # breakpoint()
         self.node2pending[node].remove(item_index)
         self.check_schedule(node, duration=duration)
 

--- a/src/xdist/scheduler/customgroup.py
+++ b/src/xdist/scheduler/customgroup.py
@@ -41,6 +41,7 @@ class CustomGroup:
     """
 
     def __init__(self, config: pytest.Config, log: Producer | None = None) -> None:
+        self.terminal = config.pluginmanager.getplugin("terminalreporter")
         self.numnodes = len(parse_spec_config(config))
         self.node2collection: dict[WorkerController, list[str]] = {}
         self.node2pending: dict[WorkerController, list[int]] = {}
@@ -54,6 +55,7 @@ class CustomGroup:
         self.maxschedchunk = self.config.getoption("maxschedchunk")
         # TODO: Type annotation incorrect
         self.dist_groups: dict[str, str] = {}
+        self.pending_groups: list[str] = []
         self.is_first_time = True
         self.do_resched = False
 
@@ -174,6 +176,7 @@ class CustomGroup:
         heuristic to influence how many tests the node is assigned.
         """
         if node.shutting_down:
+            self.terminal.write_line(f"{node.workerinput['workerid']} is already shutting down")
             return
         # if len(self.node2pending[node]) == 1:
         #     node.shutdown()
@@ -191,14 +194,14 @@ class CustomGroup:
             #         any_working = True
 
             if not any_working and from_dsession:
-                for dist_group_key in self.dist_groups:
+                if self.pending_groups:
+                    dist_group_key = self.pending_groups.pop(0)
                     dist_group = self.dist_groups[dist_group_key]
                     nodes = cycle(self.nodes[0:dist_group['group_workers']])
                     for _ in range(len(dist_group['test_indices'])):
                         self._send_tests_group(next(nodes), 1, dist_group_key)
-                    pending_nodes = self.nodes[0:dist_group['group_workers']]
                     del self.dist_groups[dist_group_key]
-                    break
+                    self.terminal.write_line(f"Processed scheduling for {dist_group_key}")
         #     # how many nodes do we have?
         #     num_nodes = len(self.node2pending)
         #     # if our node goes below a heuristic minimum, fill it out to
@@ -217,7 +220,10 @@ class CustomGroup:
         #         maxschedchunk = max(2 - len(node_pending), self.maxschedchunk)
         #         self._send_tests(node, min(num_send, maxschedchunk))
         else:
-            node.shutdown()
+            pending = self.node2pending.get(node)
+            if len(pending) < 2:
+                self.terminal.write_line(f"Shutting down {node.workerinput['workerid']} because only one case is pending")
+                node.shutdown()
 
         self.log("num items waiting for node:", len(self.pending))
 
@@ -261,6 +267,7 @@ class CustomGroup:
 
         # Initial distribution already happened, reschedule on all nodes
         if self.collection is not None:
+            #self.terminal.write_line("\nRe-scheduling")
             for node in self.nodes:
                 self.check_schedule(node)
             return
@@ -305,8 +312,10 @@ class CustomGroup:
                     'pending_indices': existing_indices
                 }
             self.dist_groups = dist_groups
+            self.pending_groups = list(dist_groups.keys())
             self.is_first_time = False
         else:
+            self.terminal.write_line("Not first time")
             for node in self.nodes:
                 self.check_schedule(node)
 
@@ -316,14 +325,17 @@ class CustomGroup:
         ## new attempt
 
         ## end new attempt
+        if not self.pending_groups:
+            return
+        dist_group_key = self.pending_groups.pop(0)
+        dist_group = self.dist_groups[dist_group_key]
+        nodes = cycle(self.nodes[0:dist_group['group_workers']])
+        for _ in range(len(dist_group['test_indices'])):
+            self._send_tests_group(next(nodes), 1, dist_group_key)
+        del self.dist_groups[dist_group_key]
+        self.terminal.write_line(f"Processed scheduling for {dist_group_key}")
 
-        for dist_group_key in self.dist_groups:
-            dist_group = self.dist_groups[dist_group_key]
-            nodes = cycle(self.nodes[0:dist_group['group_workers']])
-            for _ in range(len(dist_group['test_indices'])):
-                self._send_tests_group(next(nodes), 1, dist_group_key)
-            del self.dist_groups[dist_group_key]
-            break
+
             #worker_int = WorkerInteractor(self.nodes[0].config, self.nodes[0].channel)
             #new_conf = self.nodes[0].config.__dict__['workerinput'] = self.nodes[0].workerinput
             #worker_int = self.nodes[0].RemoteHook.pytest_xdist_getremotemodule(self).WorkerInteractor(new_conf, self.nodes[0].channel)
@@ -384,6 +396,7 @@ class CustomGroup:
             for test_index in tests_per_node:
                 self.pending.remove(test_index)
             self.node2pending[node].extend(tests_per_node)
+            #self.terminal.write_line(f"Send {'-'.join([str(x) for x in tests_per_node])} to {node.workerinput['workerid']}")
             node.send_runtest_some(tests_per_node)
 
 

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -302,8 +302,6 @@ class WorkerController:
         self._down = False
         self._shutdown_sent = False
         self.log = Producer(f"workerctl-{gateway.id}", enabled=config.option.debug)
-        self.is_custom = False
-        self.tests_total = []
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self.gateway.id}>"

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -302,6 +302,8 @@ class WorkerController:
         self._down = False
         self._shutdown_sent = False
         self.log = Producer(f"workerctl-{gateway.id}", enabled=config.option.debug)
+        self.is_custom = False
+        self.tests_total = []
 
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self.gateway.id}>"

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -11,6 +11,7 @@ from typing import Callable
 from typing import Literal
 from typing import Sequence
 from typing import Union
+from typing import Optional
 import uuid
 import warnings
 
@@ -82,7 +83,7 @@ class NodeManager:
     def setup_nodes(
         self,
         putevent: Callable[[tuple[str, dict[str, Any]]], None],
-        max_nodes: Union[int, None] = None    
+        max_nodes: Optional[int] = None    
     ) -> list[WorkerController]:
         self.config.hook.pytest_xdist_setupnodes(config=self.config, specs=self.specs)
         self.trace("setting up nodes")

--- a/src/xdist/workermanage.py
+++ b/src/xdist/workermanage.py
@@ -82,9 +82,12 @@ class NodeManager:
     def setup_nodes(
         self,
         putevent: Callable[[tuple[str, dict[str, Any]]], None],
+        max_nodes: Union[int, None] = None    
     ) -> list[WorkerController]:
         self.config.hook.pytest_xdist_setupnodes(config=self.config, specs=self.specs)
         self.trace("setting up nodes")
+        if max_nodes:
+            return [self.setup_node(spec, putevent) for spec in self.specs[0:max_nodes]]
         return [self.setup_node(spec, putevent) for spec in self.specs]
 
     def setup_node(

--- a/xdist-testing-ntop/README.md
+++ b/xdist-testing-ntop/README.md
@@ -1,6 +1,7 @@
 # Testing pytest-xdist Scheduler Custumization
-
-Run with `python -m pytest test.py`
+- Run with `python -m pytest test.py` to run tests
+- Run with `python -m pytest test.py -n <worker count> --dist customgroup --junit-xml results.xml -v` to use new scheduler + report to xml and have verbose terminal output
+    - Verbose terminal output is semi-required when using customgroup. It allows the user to confirm the correct tests are running with the correct number of processes.
 
 ## Notes:
 - Install local pytest with `python -m pip install .`

--- a/xdist-testing-ntop/README.md
+++ b/xdist-testing-ntop/README.md
@@ -1,9 +1,14 @@
 # Testing pytest-xdist Scheduler Custumization
 - Run with `python -m pytest test.py` to run tests
-- Run with `python -m pytest test.py -n <worker count> --dist customgroup --junit-xml results.xml -v` to use new scheduler + report to xml and have verbose terminal output
+- Run with `python -m pytest test.py -n <max worker count> --dist customgroup --junit-xml results.xml -v` to use new scheduler + report to xml and have verbose terminal output
     - Verbose terminal output is semi-required when using customgroup. It allows the user to confirm the correct tests are running with the correct number of processes.
 
 ## Notes:
-- Install local pytest with `python -m pip install .`
-- Can set breakpoints, default scheduler is `load.py` and breakpoint in the init method are hit when running tests with `-n`
-- 
+- Install local pytest with `python -m pip install .` or `python -m pip install -e .`
+    - When ran from root of `pytest-xdist` repository
+
+## Using Customgroup
+- Add pytest mark `xdist_custom(name="<group_name>_<num_workers>")` to tests
+    - Tests without this marking will use the maximum worker count specified by `-n` argument
+- Add `xdist_custom` to `pytest.ini` to avoid warnings about unregistered marks
+- Run tests as detailed above

--- a/xdist-testing-ntop/README.md
+++ b/xdist-testing-ntop/README.md
@@ -1,0 +1,8 @@
+# Testing pytest-xdist Scheduler Custumization
+
+Run with `python -m pytest test.py`
+
+## Notes:
+- Install local pytest with `python -m pip install .`
+- Can set breakpoints, default scheduler is `load.py` and breakpoint in the init method are hit when running tests with `-n`
+- 

--- a/xdist-testing-ntop/pytest.ini
+++ b/xdist-testing-ntop/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+log_cli_level=0
 
 markers=
     low: 4

--- a/xdist-testing-ntop/pytest.ini
+++ b/xdist-testing-ntop/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+
+markers=
+    low: 4
+    med: 2
+    high: 1
+    xdist_custom

--- a/xdist-testing-ntop/pytest.ini
+++ b/xdist-testing-ntop/pytest.ini
@@ -2,7 +2,4 @@
 log_cli_level=0
 
 markers=
-    low: 4
-    med: 2
-    high: 1
     xdist_custom

--- a/xdist-testing-ntop/test.py
+++ b/xdist-testing-ntop/test.py
@@ -1,0 +1,77 @@
+import pytest
+import time
+import pathlib
+
+@pytest.mark.xdist_custom(name="low_4")
+def test_writer():
+    time.sleep(2)
+    file_path = pathlib.Path("/home/chrisiaconetti/dev/test_ran.txt")
+    with open(file_path, 'w') as writer:
+        writer.write("The test ran!\n")
+    assert True
+
+@pytest.mark.xdist_custom(name="low_4")
+def test_1():
+    time.sleep(2)
+    assert True
+
+@pytest.mark.xdist_custom(name="low_4")
+def test_2():
+    time.sleep(2)
+    assert True
+
+@pytest.mark.xdist_custom(name="low_4")
+def test_3():
+    time.sleep(2)
+    assert True
+
+@pytest.mark.xdist_custom(name="low_4")
+def test_4():
+    time.sleep(2)
+    assert True
+
+@pytest.mark.xdist_custom(name="med_2")
+def test_5():
+    time.sleep(10)
+    assert True
+
+@pytest.mark.xdist_custom(name="med_2")
+def test_6():
+    time.sleep(10)
+    assert True
+
+# @pytest.mark.xdist_custom(name="med_2")
+# def test_7():
+#     time.sleep(10)
+#     assert True
+
+# @pytest.mark.xdist_custom(name="med_2")
+# def test_8():
+#     time.sleep(10)
+#     assert True
+
+# @pytest.mark.xdist_custom(name="high_1")
+# def test_9():
+#     time.sleep(30)
+#     assert True
+
+# @pytest.mark.xdist_custom(name="high_1")
+# def test_10():
+#     time.sleep(30)
+#     assert True
+
+# def test_11():
+#     time.sleep(1)
+#     assert True
+
+# def test_12():
+#     time.sleep(1)
+#     assert True
+
+# def test_13():
+#     time.sleep(1)
+#     assert True
+
+# def test_14():
+#     time.sleep(1)
+#     assert True

--- a/xdist-testing-ntop/test.py
+++ b/xdist-testing-ntop/test.py
@@ -2,13 +2,13 @@ import pytest
 import time
 import pathlib
 
-@pytest.mark.xdist_custom(name="low_4")
-def test_writer():
-    time.sleep(2)
-    file_path = pathlib.Path("/home/chrisiaconetti/dev/test_ran.txt")
-    with open(file_path, 'w') as writer:
-        writer.write("The test ran!\n")
-    assert True
+# @pytest.mark.xdist_custom(name="low_4")
+# def test_writer():
+#     time.sleep(2)
+#     file_path = pathlib.Path("/home/chrisiaconetti/dev/test_ran.txt")
+#     with open(file_path, 'w') as writer:
+#         writer.write("The test ran!\n")
+#     assert True
 
 @pytest.mark.xdist_custom(name="low_4")
 def test_1():
@@ -40,38 +40,38 @@ def test_6():
     time.sleep(10)
     assert True
 
-# @pytest.mark.xdist_custom(name="med_2")
-# def test_7():
-#     time.sleep(10)
-#     assert True
+@pytest.mark.xdist_custom(name="med_2")
+def test_7():
+    time.sleep(10)
+    assert True
 
-# @pytest.mark.xdist_custom(name="med_2")
-# def test_8():
-#     time.sleep(10)
-#     assert True
+@pytest.mark.xdist_custom(name="med_2")
+def test_8():
+    time.sleep(10)
+    assert True
 
-# @pytest.mark.xdist_custom(name="high_1")
-# def test_9():
-#     time.sleep(30)
-#     assert True
+@pytest.mark.xdist_custom(name="high_1")
+def test_9():
+    time.sleep(30)
+    assert True
 
-# @pytest.mark.xdist_custom(name="high_1")
-# def test_10():
-#     time.sleep(30)
-#     assert True
+@pytest.mark.xdist_custom(name="high_1")
+def test_10():
+    time.sleep(30)
+    assert True
 
-# def test_11():
-#     time.sleep(1)
-#     assert True
+def test_11():
+    time.sleep(1)
+    assert True
 
-# def test_12():
-#     time.sleep(1)
-#     assert True
+def test_12():
+    time.sleep(1)
+    assert True
 
-# def test_13():
-#     time.sleep(1)
-#     assert True
+def test_13():
+    time.sleep(1)
+    assert True
 
-# def test_14():
-#     time.sleep(1)
-#     assert True
+def test_14():
+    time.sleep(1)
+    assert True

--- a/xdist-testing-ntop/test.py
+++ b/xdist-testing-ntop/test.py
@@ -22,34 +22,59 @@ def test_4():
     time.sleep(2)
     assert True
 
+# @pytest.mark.xdist_custom(name="low_4")
+# def test_4a():
+#     time.sleep(2)
+#     assert True
+#
+# @pytest.mark.xdist_custom(name="low_4")
+# def test_4b():
+#     time.sleep(2)
+#     assert True
+#
+# @pytest.mark.xdist_custom(name="low_4")
+# def test_4c():
+#     time.sleep(2)
+#     assert True
+#
+# @pytest.mark.xdist_custom(name="low_4")
+# def test_4d():
+#     time.sleep(2)
+#     assert True
+#
+# @pytest.mark.xdist_custom(name="low_4")
+# def test_4e():
+#     time.sleep(2)
+#     assert True
+
 @pytest.mark.xdist_custom(name="med_2")
 def test_5():
-    time.sleep(10)
+    time.sleep(3)
     assert True
 
 @pytest.mark.xdist_custom(name="med_2")
 def test_6():
-    time.sleep(10)
+    time.sleep(3)
     assert True
 
 @pytest.mark.xdist_custom(name="med_2")
 def test_7():
-    time.sleep(10)
+    time.sleep(3)
     assert True
 
 @pytest.mark.xdist_custom(name="med_2")
 def test_8():
-    time.sleep(10)
+    time.sleep(3)
     assert True
 
 @pytest.mark.xdist_custom(name="high_1")
 def test_9():
-    time.sleep(30)
+    time.sleep(5)
     assert True
 
 @pytest.mark.xdist_custom(name="high_1")
 def test_10():
-    time.sleep(30)
+    time.sleep(5)
     assert True
 
 def test_11():

--- a/xdist-testing-ntop/test.py
+++ b/xdist-testing-ntop/test.py
@@ -1,14 +1,6 @@
 import pytest
 import time
-import pathlib
 
-# @pytest.mark.xdist_custom(name="low_4")
-# def test_writer():
-#     time.sleep(2)
-#     file_path = pathlib.Path("/home/chrisiaconetti/dev/test_ran.txt")
-#     with open(file_path, 'w') as writer:
-#         writer.write("The test ran!\n")
-#     assert True
 
 @pytest.mark.xdist_custom(name="low_4")
 def test_1():


### PR DESCRIPTION
### Summary
[TUR-21619](https://ntopology.atlassian.net/browse/TUR-21619) is a prototype method of executing groups of pytest test cases in series with each group running it's specific test cases in parallel with a variable number of workers.

Tests can be marked with a custom mark. This custom mark specifies an arbitrary group name, and the number of processes to run tests in that group with, with the number of processes separated from the group name by an underscore.

Due to limitations in `pytest`/`execnet` a shutdown signal must be sent to a node when one test case remains on the node (the test case is actually ran immediately, but we do not receive feedback through the channel until a shutdown signal is sent due to an old design decision in `pytest`). Because of this, in order to run additional tests after a group is nearly complete (when each worker has at most 1 test remaining), we must shutdown each node, recreate each node, and then schedule more tests. This adds overhead as we must teardown + startup nodes, however, this overhead is on the order of 1 second per teardown/startup. If this custom scheduling method allows us to save more than 1 second in test execution, it is worth the increased overhead cost.

Note: The `-n` argument with `--dist customgroup` is the **maximum** number of worker processes. If `-n` specifies `4` but a specific group specifies `8`, the specific group will be ran across only 4 nodes, we will never spin up more nodes than the `-n` argument allows.

**Prototype, not necessarily meant to be final implementation. Lots of messy comments/not well documented**.

### Testing
- See `README.md` added in this PR
- Test [windows ntop-tests-silver-no-render](http://35.227.27.17:8080/job/turbo-ondemand-all/7/) command line only, skipping build
- Test [linux ntop-tests-silver-no-render](http://35.227.27.17:8080/job/turbo-ondemand-all/6/) skipping build

[TUR-21619]: https://ntopology.atlassian.net/browse/TUR-21619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ