### PR TITLE
TUR-21619: Patch pytest error

### DIFF
--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -409,7 +409,8 @@ class DSession:
             else:
                 self.ready_to_run_tests = True
                 self.sched.schedule()
-                self.reset_nodes_if_needed()
+                if isinstance(self.sched, CustomGroup):
+                    self.reset_nodes_if_needed()
 
     def worker_logstart(
         self,

--- a/src/xdist/dsession.py
+++ b/src/xdist/dsession.py
@@ -402,15 +402,17 @@ class DSession:
                 self.terminal.write_line("")
                 if self.config.option.verbose > 0:
                     self.report_line(f"[-] [dse] scheduling tests via {self.sched.__class__.__name__}")
-            if isinstance(self.sched, CustomGroup) and self.ready_to_run_tests and self.are_all_active_nodes_collected():
-                # we're coming back here after finishing a batch of tests - so start the next batch
-                self.reschedule()
-                self.reset_nodes_if_needed()
-            else:
-                self.ready_to_run_tests = True
-                self.sched.schedule()
-                if isinstance(self.sched, CustomGroup):
+            if isinstance(self.sched, CustomGroup):
+                if self.ready_to_run_tests and self.are_all_active_nodes_collected():
+                    # we're coming back here after finishing a batch of tests - so start the next batch
+                    self.reschedule()
                     self.reset_nodes_if_needed()
+                else:
+                    self.ready_to_run_tests = True
+                    self.sched.schedule()
+                    self.reset_nodes_if_needed()
+            else:
+                self.sched.schedule()
 
     def worker_logstart(
         self,


### PR DESCRIPTION
### Summary
Correct bug in pytest xdist customgroup scheduler prototype.

### Testing
1. Run `python -m pytest test.py -n 4 --junit-xml results.xml -v -m "not xdist_custom"` from `pytest-xdist/xdist-testing-ntop` with `main` pip installed. Should see pytest internal error
2. Run same command with this branch pip installed, should observe test process working as intended.